### PR TITLE
Added nologfile=y parameter to avoid this

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ exit;
 EOL
 
 	su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/sqlplus -S / as sysdba @/tmp/impdp.sql"
-	su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/impdp IMPDP/IMPDP directory=IMPDP dumpfile=$DUMP_FILE"
+	su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/impdp IMPDP/IMPDP directory=IMPDP dumpfile=$DUMP_FILE nologfile=y"
 	#Disable IMPDP user
 	echo -e 'ALTER USER IMPDP ACCOUNT LOCK;\nexit;' | su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/sqlplus -S / as sysdba"
 }


### PR DESCRIPTION
In https://github.com/MaksymBilenko/docker-oracle-xe-11g/blob/master/entrypoint.sh#L34

ORA-39002: invalid operation
**ORA-39070: Unable to open the log file.**
ORA-29283: invalid file operation
ORA-06512: at "SYS.UTL_FILE", line 536
ORA-29283: invalid file operation

Added `nologfile=y` parameter to avoid this.